### PR TITLE
The H2Truncator now resets the sequences.

### DIFF
--- a/src/main/java/nl/_42/database/truncator/H2Truncator.java
+++ b/src/main/java/nl/_42/database/truncator/H2Truncator.java
@@ -10,12 +10,15 @@ import java.util.stream.Collectors;
 public class H2Truncator extends AbstractDatabaseTruncator {
 
     public static final String TABLE_NAME_KEY = "TABLE_NAME";
+    public static final String SEQUENCE_NAME_KEY = "SEQUENCE_NAME";
 
     List<String> tables = new ArrayList<>();
+    List<String> sequences = new ArrayList<>();
 
     public H2Truncator(DataSource dataSource) {
         super(dataSource);
         determineTables();
+        determineSequences();
     }
 
     private void determineTables() {
@@ -25,9 +28,17 @@ public class H2Truncator extends AbstractDatabaseTruncator {
                 .collect(Collectors.toList()));
     }
 
+    private void determineSequences() {
+        String query = "SELECT SEQUENCE_NAME FROM INFORMATION_SCHEMA.SEQUENCES WHERE SEQUENCE_SCHEMA='PUBLIC'";
+        this.sequences.addAll(jdbcTemplate.queryForList(query).stream()
+                .map(sequenceInfo -> (String) sequenceInfo.get(SEQUENCE_NAME_KEY))
+                .collect(Collectors.toList()));
+    }
+
     public void truncate() throws MetaDataAccessException {
         jdbcTemplate.execute("SET REFERENTIAL_INTEGRITY FALSE;");
         tables.forEach(table -> jdbcTemplate.execute("TRUNCATE TABLE " + table));
+        sequences.forEach(sequence -> jdbcTemplate.execute("ALTER SEQUENCE " + sequence + " RESTART WITH 1"));
         jdbcTemplate.execute("SET REFERENTIAL_INTEGRITY TRUE;");
     }
 


### PR DESCRIPTION
The reason this is handy is because now you can deterministically expect
which id gets assigned to a new Entity in your unit tests. This could
cause issues when running the test in isolation vs running the whole
test suite.

For example when testing the following suite you expect both test to pass:

```Java
@Test
public void save() {
    Car car = carRepository.save(new Car);
    assertEquals(car.id, 1);
}

@Test
public void save_withLicencePlate() {
    Car car = carRepository.save(new Car("PB-HL-12"));
    assertEquals(1, car.id); // <- This id will be 2!
    assertEquals("PB-HL-12", car.licensePlate);
}
```

However this is not true at the moment, because the in `save_withLicencePlate`
the cars 'id' table is not reset so it has id 2. This is confusing.

However running only `save_withLicencePlate` will work.

Closes #1