### PR TITLE
Speeded up Postgres truncation by combining queries

### DIFF
--- a/src/main/java/nl/_42/database/truncator/postgres/PostgresDeletionStrategy.java
+++ b/src/main/java/nl/_42/database/truncator/postgres/PostgresDeletionStrategy.java
@@ -1,16 +1,10 @@
 package nl._42.database.truncator.postgres;
 
-import nl._42.database.truncator.config.DatabaseTruncatorProperties;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.util.StopWatch;
-
 import javax.sql.DataSource;
-import java.util.List;
+
+import nl._42.database.truncator.config.DatabaseTruncatorProperties;
 
 public class PostgresDeletionStrategy extends AbstractPostgresTruncationStrategy {
-
-    private static final Logger LOGGER = LoggerFactory.getLogger(PostgresDeletionStrategy.class);
 
     public PostgresDeletionStrategy(DataSource dataSource, DatabaseTruncatorProperties properties) {
         super(dataSource, properties);
@@ -18,30 +12,8 @@ public class PostgresDeletionStrategy extends AbstractPostgresTruncationStrategy
 
     @Override
     public void executePostgresTruncate() {
-        executeSql(tables,"disable triggers", "ALTER TABLE %s DISABLE TRIGGER ALL");
-        executeSql(tables,"delete tables", "DELETE FROM %s");
-        executeSql(tables,"enable triggers", "ALTER TABLE %s ENABLE TRIGGER ALL");
+        executeSql(tables,"disable triggers", "ALTER TABLE %s DISABLE TRIGGER ALL;");
+        executeSql(tables,"delete tables", "DELETE FROM %s;");
+        executeSql(tables,"enable triggers", "ALTER TABLE %s ENABLE TRIGGER ALL;");
     }
-
-    private void executeSql(List<String> records, String title, String sql) {
-        StopWatch stopWatch = new StopWatch();
-        stopWatch.start();
-        records.forEach(record -> executeSql(null, String.format(sql, record)));
-        stopWatch.stop();
-        LOGGER.debug(title + " took: " + stopWatch.getTotalTimeMillis() + " ms");
-    }
-
-    private void executeSql(String title, String sql) {
-        StopWatch stopWatch = null;
-        if (title != null) {
-            stopWatch = new StopWatch();
-            stopWatch.start();
-        }
-        jdbcTemplate.execute(sql);
-        if (stopWatch != null) {
-            stopWatch.stop();
-            LOGGER.debug(title + " took: " + stopWatch.getTotalTimeMillis() + " ms");
-        }
-    }
-
 }

--- a/src/main/java/nl/_42/database/truncator/postgres/PostgresTruncationStrategy.java
+++ b/src/main/java/nl/_42/database/truncator/postgres/PostgresTruncationStrategy.java
@@ -1,8 +1,8 @@
 package nl._42.database.truncator.postgres;
 
-import nl._42.database.truncator.config.DatabaseTruncatorProperties;
-
 import javax.sql.DataSource;
+
+import nl._42.database.truncator.config.DatabaseTruncatorProperties;
 
 public class PostgresTruncationStrategy extends AbstractPostgresTruncationStrategy {
 
@@ -12,7 +12,6 @@ public class PostgresTruncationStrategy extends AbstractPostgresTruncationStrate
 
     @Override
     public void executePostgresTruncate() {
-        tables.forEach(table -> jdbcTemplate.execute("TRUNCATE TABLE " + table + " CASCADE"));
+        executeSql(tables, "truncate tables", "TRUNCATE TABLE %s CASCADE;");
     }
-
 }


### PR DESCRIPTION
Previously, separate queries where executed when
selecting the tables where the row count was larger
than 0 or when performing the truncation/deletion
itself.

Both these queries have been merged into a single
query.

After the change, when running the tests of the application
I was using this library on, the PostgresDeletionStrategy
was actually slightly faster than the PostgresOptimizedDeletionStrategy.
This has however only been tested one time with one single application
so more research is needed to determine if this change makes the optimized
deletion strategy obsolete.

I could not test the PostgresTruncationStrategy as this also did not work
in my application with the previous code.