### PR TITLE
DatabaseTruncator is now upgraded to work with Spring Boot 2.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.2</version>
+        <version>2.5.0</version>
     </parent>
 
     <name>Database Truncator</name>
@@ -116,7 +116,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>6.0.5</version>
+                <version>6.1.6</version>
                 <configuration>
                     <failBuildOnAnyVulnerability>true</failBuildOnAnyVulnerability>
                     <skipProvidedScope>true</skipProvidedScope>

--- a/src/main/java/nl/_42/database/truncator/Platform.java
+++ b/src/main/java/nl/_42/database/truncator/Platform.java
@@ -1,15 +1,22 @@
 package nl._42.database.truncator;
 
-import nl._42.database.truncator.config.DatabaseTruncatorProperties;
-import nl._42.database.truncator.shared.AbstractTruncationStrategy;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static nl._42.database.truncator.TruncationStrategy.H2_TRUNCATION;
+import static nl._42.database.truncator.TruncationStrategy.HSQLDB_TRUNCATION;
+import static nl._42.database.truncator.TruncationStrategy.MARIADB_TRUNCATION;
+import static nl._42.database.truncator.TruncationStrategy.POSTGRES_DELETION;
+import static nl._42.database.truncator.TruncationStrategy.POSTGRES_DELETION_OPTIMIZED;
+import static nl._42.database.truncator.TruncationStrategy.POSTGRES_TRUNCATION;
 
-import javax.sql.DataSource;
 import java.util.Arrays;
 import java.util.List;
 
-import static nl._42.database.truncator.TruncationStrategy.*;
+import javax.sql.DataSource;
+
+import nl._42.database.truncator.config.DatabaseTruncatorProperties;
+import nl._42.database.truncator.shared.AbstractTruncationStrategy;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public enum Platform {
     H2(H2_TRUNCATION),
@@ -40,7 +47,7 @@ public enum Platform {
         }
         throw new ExceptionInInitializerError(
                 "The Database Truncator cannot be configured. Illegal platform: " + platformText + ". Set " +
-                "spring.datasource.platform value to non-empty, valid value");
+                        "spring.sql.init.platform value to non-empty, valid value");
     }
 
     public TruncationStrategy determineStrategy(TruncationStrategy strategy) {

--- a/src/main/java/nl/_42/database/truncator/config/DatabaseTruncatorAutoConfiguration.java
+++ b/src/main/java/nl/_42/database/truncator/config/DatabaseTruncatorAutoConfiguration.java
@@ -1,7 +1,10 @@
 package nl._42.database.truncator.config;
 
+import javax.sql.DataSource;
+
 import nl._42.database.truncator.DatabaseTruncator;
 import nl._42.database.truncator.Platform;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -11,15 +14,14 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.autoconfigure.sql.init.SqlInitializationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import javax.sql.DataSource;
-
 @Configuration
 @ConditionalOnBean(DataSource.class)
-@ConditionalOnProperty(value= "spring.datasource.platform", matchIfMissing = true)
+@ConditionalOnProperty(value = "spring.sql.init.platform", matchIfMissing = true)
 @AutoConfigureAfter({ DataSourceAutoConfiguration.class, HibernateJpaAutoConfiguration.class })
 @EnableConfigurationProperties(DatabaseTruncatorProperties.class)
 public class DatabaseTruncatorAutoConfiguration {
@@ -33,22 +35,22 @@ public class DatabaseTruncatorAutoConfiguration {
 
         private final DataSource dataSource;
 
-        private final DataSourceProperties dataSourceProperties;
+        private final SqlInitializationProperties sqlInitializationProperties;
 
         private final DatabaseTruncatorProperties databaseTruncatorProperties;
 
         @SuppressWarnings("SpringJavaAutowiringInspection")
-        public DatabaseTruncatorConfiguration(DataSource dataSource, DataSourceProperties dataSourceProperties,
-                                              DatabaseTruncatorProperties databaseTruncatorProperties) {
+        public DatabaseTruncatorConfiguration(DataSource dataSource, SqlInitializationProperties sqlInitializationProperties,
+                DatabaseTruncatorProperties databaseTruncatorProperties) {
             LOGGER.info("Configuring DatabaseTruncator");
             this.dataSource = dataSource;
-            this.dataSourceProperties = dataSourceProperties;
+            this.sqlInitializationProperties = sqlInitializationProperties;
             this.databaseTruncatorProperties = databaseTruncatorProperties;
         }
 
         @Bean
         public DatabaseTruncator databaseTruncator() {
-            Platform platform = Platform.determinePlatform(dataSourceProperties.getPlatform());
+            Platform platform = Platform.determinePlatform(sqlInitializationProperties.getPlatform());
             return platform.createTruncator(dataSource, databaseTruncatorProperties);
         }
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -6,7 +6,7 @@ spring.datasource.url=jdbc:h2:mem:testdb
 spring.datasource.username=sa
 spring.datasource.password=
 spring.datasource.driver-class-name=org.h2.Driver
-spring.datasource.platform=h2
+spring.sql.init.platform=h2
 
 # Ignored table(unit test only)
 database-truncator.exclude=IGNORED_TABLE


### PR DESCRIPTION
- In DatabaseTruncatorAutoConfiguration changed the
spring.datasource.platform config option to the new
spring.sql.init.platform config. This means that it will now only
support Spring Boot 2.5.0 and up.